### PR TITLE
fix: :sparkles: feat(confirm-create-new-password): Implement new password creation functionality

### DIFF
--- a/actions/new-password.ts
+++ b/actions/new-password.ts
@@ -1,0 +1,57 @@
+"use server";
+
+import * as z from "zod";
+import bcrypt from "bcryptjs";
+
+import { NewPasswordSchema } from "@/schemas";
+import { getPasswordResetTokenByToken } from "@/data/password-reset-token";
+import { getUserByEmail } from "@/data/user";
+import { db } from "@/lib/db";
+
+export const newPassword = async (
+  values: z.infer<typeof NewPasswordSchema>,
+  token?: string | null
+) => {
+  if (!token) {
+    return { error: "Missing token!" };
+  }
+
+  const validatedFields = NewPasswordSchema.safeParse(values);
+
+  if (!validatedFields.success) {
+    return { error: "Invalid fields!" };
+  }
+
+  const { password } = validatedFields.data;
+
+  const existingToken = await getPasswordResetTokenByToken(token);
+
+  if (!existingToken) {
+    return { error: "Invalid token!" };
+  }
+
+  const hasExpired = new Date(existingToken.expires) < new Date();
+
+  if (hasExpired) {
+    return { error: "Token has expired!" };
+  }
+
+  const existingUser = await getUserByEmail(existingToken.email);
+
+  if (!existingUser) {
+    return { error: "User email does not exist!" };
+  }
+
+  const hashedPassword = await bcrypt.hash(password, 10);
+
+  await db.user.update({
+    where: { id: existingUser.id },
+    data: { password: hashedPassword },
+  });
+
+  await db.passwordResetToken.delete({
+    where: { id: existingToken.id },
+  });
+
+  return { success: "Password updated!" };
+};

--- a/app/auth/new-password/page.tsx
+++ b/app/auth/new-password/page.tsx
@@ -1,0 +1,5 @@
+import NewPasswordForm from "@/components/auth/new-password-form";
+
+export default function NewPasswordPage() {
+  return <NewPasswordForm />;
+}

--- a/components/auth/new-password-form.tsx
+++ b/components/auth/new-password-form.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import * as z from "zod";
+import { useForm } from "react-hook-form";
+import { useState, useTransition } from "react";
+import { useSearchParams } from "next/navigation";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { NewPasswordSchema } from "@/schemas";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import CardWrapper from "@/components/auth/card-wrapper";
+import { Button } from "@/components/ui/button";
+import { newPassword } from "@/actions/new-password";
+import FormError from "@/components/form-error";
+import FormSuccess from "@/components/form-success";
+
+const NewPasswordForm = () => {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
+  const [error, setError] = useState<string | undefined>("");
+  const [success, setSuccess] = useState<string | undefined>("");
+  const [isPending, startTransition] = useTransition();
+
+  const form = useForm<z.infer<typeof NewPasswordSchema>>({
+    resolver: zodResolver(NewPasswordSchema),
+    defaultValues: {
+      password: "",
+      passwordConfirmation: "",
+    },
+  });
+
+  const onSubmit = (values: z.infer<typeof NewPasswordSchema>) => {
+    startTransition(() => {
+      newPassword(values, token).then((data) => {
+        setError(data?.error);
+        setSuccess(data?.success);
+      });
+    });
+
+    form.reset();
+    setSuccess("");
+    setError("");
+  };
+
+  return (
+    <CardWrapper
+      headerLabel="Enter a new password"
+      backButtonLabel="Back to login"
+      backButtonHref="/auth/login"
+    >
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="space-y-6"
+        >
+          <div className="space-y-4">
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Password</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      disabled={isPending}
+                      placeholder="******"
+                      type="password"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="passwordConfirmation"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Confirm your password</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      disabled={isPending}
+                      type="password"
+                      placeholder="******"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          {error && <FormError message={error} />}
+          {success && <FormSuccess message={success} />}
+          <Button
+            disabled={isPending}
+            type="submit"
+            className="w-full hover:bg-sky-400"
+          >
+            Reset password
+          </Button>
+        </form>
+      </Form>
+    </CardWrapper>
+  );
+};
+
+export default NewPasswordForm;


### PR DESCRIPTION
Description:
This commit introduces the new password creation functionality. The changes are part of the ongoing work on the `confirm-create-new-password` branch.
- New files `actions/new-password.ts`, `app/auth/new-password/`, and `components/auth/new-password-form.tsx` have been added to handle the new password creation process.

Changes:
- Add new files for handling new password creation process

This commit doesn't introduce any breaking changes. The updates are compatible with the existing codebase.
Co-authored-by: Ricardo Esteves <30535937+RicardoGEsteves@users.noreply.github.com>