### PR TITLE
docs: :pencil2: docs(fix-typo-readme): Correct typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The concept behind this toolkit is to create a scalable and maintainable solutio
   ![Client](/public/demo-images/client.png)
 - Client Page Example with 2FA Enabled
   ![Client](/public/demo-images/2faEnabled.png)
-- Server Page Example with 2FA Enabled
+- Server Page Example with 2FA Disabled
   ![Server](/public/demo-images/server.png)
 - Mobile Navigation
   ![Mobile Navigation](/public/demo-images/mobileNavigation.png)


### PR DESCRIPTION
Description:
This commit corrects a typo in the README.md file. The changes are part of the ongoing work on the `fix-typo-readme` branch.
- In `README.md`, the description for the "Server Page Example with 2FA Enabled" image has been corrected to "Server Page Example with 2FA Disabled".

Changes:
- Correct typo in `README.md` for the description of the "Server Page Example with 2FA Enabled" image

This commit doesn't introduce any breaking changes. The updates are compatible with the existing codebase and ensure accurate information is provided to users or contributors who are reading the README.md file.
Co-authored-by: Ricardo Esteves <30535937+RicardoGEsteves@users.noreply.github.com>